### PR TITLE
fix: add express-session middleware to support login sessions (#10)

### DIFF
--- a/server/src/config/passportConfig.ts
+++ b/server/src/config/passportConfig.ts
@@ -1,11 +1,7 @@
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
-import User from '../models/User';  // your Mongoose User model
-import jwt from 'jsonwebtoken';
+import User from '../models/User';
 
-// Passport requires a "verify" callback, which is invoked
-// after Google sends back user info. Here, you either create
-// a new user or find an existing one in the DB.
 passport.use(
   new GoogleStrategy(
     {
@@ -15,44 +11,51 @@ passport.use(
     },
     async (accessToken, refreshToken, profile, done) => {
       try {
-        // profile contains Google user info
-        // e.g. profile.emails, profile.displayName, etc.
-        const email = profile.emails?.[0].value;
+        // Extract email from Google profile
+        const email = profile.emails?.[0]?.value;
         if (!email) {
           return done(new Error('No email found in Google profile'));
         }
 
-        // Check if user already exists
+        // Look up existing user or create a new one (do not use .lean())
         let user = await User.findOne({ email });
         if (!user) {
-          // Create a new user
           user = await User.create({
             name: profile.displayName,
             email,
-            // You can store a random placeholder or hashed password
-            // because we won't use local password for Google logins
             password: 'google_oauth_no_password',
-            // role: 'USER' by default
           });
         }
 
-        // Pass user to the next step
+        // Log the user so we can check it has an _id
+        console.log('Google strategy user:', user);
         return done(null, user);
       } catch (err) {
+        console.error('GoogleStrategy error:', err);
         return done(err);
       }
     }
   )
 );
 
-// (Optional) If you use session-based auth, you need serialize/deserialize:
+// Serialize the user: convert the MongoDB ObjectId to a string
 passport.serializeUser((user: any, done) => {
-  done(null, user.id);
+  console.log('Serializing user:', user);
+  if (!user || !user._id) {
+    return done(new Error('No user or missing _id in serializeUser'));
+  }
+  done(null, user._id.toString());
 });
-passport.deserializeUser((id: string, done) => {
-  User.findById(id)
-    .then(user => done(null, user))
-    .catch(err => done(err));
+
+// Deserialize the user from the stored id
+passport.deserializeUser(async (id: string, done) => {
+  try {
+    console.log('Deserializing user with id:', id);
+    const user = await User.findById(id);
+    done(null, user);
+  } catch (err) {
+    done(err);
+  }
 });
 
 export default passport;

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -7,7 +7,7 @@ export interface IUser extends Document {
   role: 'USER' | 'ADMIN';
 }
 
-const userSchema: Schema = new Schema(
+const userSchema = new Schema<IUser>(
   {
     name: { type: String, required: true },
     email: { type: String, required: true, unique: true },


### PR DESCRIPTION
This commit fixes the "Login sessions require session support" error encountered when using Passport Google OAuth. The error occurred because Passport's session support was initialized without Express sessions being set up.

Changes made:
- Imported and configured `express-session` in `src/server.ts` before initializing Passport.
- Moved the Passport initialization (`passport.initialize()` and `passport.session()`) to occur after setting up the session middleware.
- Ensured that our Passport configuration is loaded early by importing it from `./src/config/passportConfig`.

These changes allow Passport to properly store and retrieve user sessions, resolving the error and enabling successful OAuth login sessions.
